### PR TITLE
bump chromiumoxide 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 [dependencies]
 async-std = "1.9"
 atty = "0.2"
-chromiumoxide = "0.3.0"
+chromiumoxide = "0.3.1"
 clap = { version = "3.0.0-beta.2", features = ["yaml"] }
 colored = "2"
 futures = "0.3"


### PR DESCRIPTION
this new release doesn't fail anymore if `rustfmt` install is missing